### PR TITLE
[WIP] Use default absinthe pipeline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,24 @@ end
 
 ## Usage
 
-To add tracing to your graphql schema, add ApolloTracing.Middleware as the
-first middleware of your middleware stack:
-```elixir
-def middleware(middlewares, field, object) do
-  [ApolloTracing.Middleware | ...your other middlewares]
-end
-```
+### The Happy Path
 
-If you have no custom middleware callback, you can simply add `use ApolloTracing` to your schema file:
+If you have no custom middleware callback and no custom pipeline, you can simply add `use ApolloTracing` to your schema file:
 
 ```elixir
 def MyApp.Schema do
   use Absinthe.Schema
   use ApolloTracing
+end
+```
+
+### Advanced
+
+To add tracing to your custom middleware, add ApolloTracing.Middleware as the
+first middleware of your middleware stack:
+```elixir
+def middleware(middlewares, field, object) do
+  [ApolloTracing.Middleware | ...your other middlewares]
 end
 ```
 
@@ -48,48 +52,11 @@ field :selected_field, :string do
 end
 ```
 
-After adding the middleware, then you want to  modify Absinthe pipeline to ApolloTracing's custom pipeline before executing queries.
-
-## Modifying pipeline with Plug
-
-To add the pipeline to your Absinthe.Plug endpoint, you can simpley use the :pipeline option:
+To add tracing to your custom pipeline, you want to modify Absinthe pipeline to ApolloTracing's custom pipeline before executing queries. In your `schema.ex`:
 
 ```elixir
-forward "/graphql", Absinthe.Plug,
-  schema: MyApp.Schema,
-  pipeline: {ApolloTracing.Pipeline, :plug}
-```
-
-If you have your own pipeline function, you can use
-ApolloTracing.Pipeline.add_phases(pipeline) function to added the phases to your pipeline before passing it to Absinthe.Plug.
-
-```elixir
-def my_pipeline_creator(config, pipeline_opts) do
-  config.schema_mod
-  |> Absinthe.Pipeline.for_document(pipeline_opts)
-  |> add_my_phases() # w.e your custom phases are
-  |> ApolloTracing.Pipeline.add_phases() # Add apollo at the end
+def pipeline(phases) do
+  phases
+  |> ApolloTracing.Pipeline.add_phases()
 end
 ```
-
-### Adding pipeline to `Absinthe.run`
-When you want to just call run a query with tracing, but without going through a Plug endpoint,
-you can build the pipeline with `ApolloTracing.Pipeline.default(schema, opts)`
-and pass that to `Absinthe.Pipeline.run`
-
-```elixir
-def custom_absinthe_runner(query, opts \\ []) do
-  pipeline = ApolloTracing.Pipeline.default(YourSchema, opts)
-  case Absinthe.Pipeline.run(query, pipeline) do
-    {:ok, %{result: result}, _} -> {:ok, result}
-    {:error, err, _} -> {:ok, err}
-  end
-end
-
-"""
-  query {
-    fielda
-    fieldb
-  }
-"""
-|> custom_absinthe_runner()

--- a/lib/apollo_tracing.ex
+++ b/lib/apollo_tracing.ex
@@ -11,6 +11,11 @@ defmodule ApolloTracing do
         [ApolloTracing.Middleware |
          Absinthe.Schema.__ensure_middleware__(middleware, field, object)]
       end
+
+      def pipeline(phases) do
+        phases
+        |> ApolloTracing.Pipeline.add_phases()
+      end
     end
   end
 end

--- a/lib/apollo_tracing/pipeline.ex
+++ b/lib/apollo_tracing/pipeline.ex
@@ -1,24 +1,4 @@
 defmodule ApolloTracing.Pipeline do
-  def default(schema, pipeline_opts \\ []) do
-    schema
-    |> Absinthe.Pipeline.for_document(pipeline_opts)
-    |> add_phases()
-  end
-
-  def plug(config, pipeline_opts \\ []) do
-    case Code.ensure_loaded(Absinthe.Plug) do
-      {:module, absinthe_plug} ->
-        absinthe_plug.default_pipeline(config, pipeline_opts)
-       |> add_phases()
-      _ ->
-        raise RuntimeError, """
-          You don't have Plug loaded, please use
-          ApolloTracing.Pipeline.default(absinthe_schema, pipeline_opts)
-          to produce a pipeline without Plug specific phases
-        """
-    end
-  end
-
   def add_phases(pipeline) do
     pipeline
     |> Absinthe.Pipeline.insert_after(

--- a/test/apollo_tracing_test.exs
+++ b/test/apollo_tracing_test.exs
@@ -4,6 +4,7 @@ defmodule ApolloTracingTest do
 
   defmodule TestSchema do
     use Absinthe.Schema
+    use ApolloTracing
 
     object :person do
       field :name, :string
@@ -17,23 +18,15 @@ defmodule ApolloTracingTest do
         end
       end
     end
-
-    def middleware(middleware, field, object) do
-      [ApolloTracing.Middleware |
-      Absinthe.Schema.__ensure_middleware__(middleware, field, object)]
-    end
   end
 
   setup_all do
-    pipeline = ApolloTracing.Pipeline.default(TestSchema, [])
-
-    result =
-    """
+    result = """
       query {
         getPerson { name age }
       }
     """
-    |> Absinthe.Pipeline.run(pipeline)
+    |> Absinthe.run(TestSchema)
     |> case do
       {:ok, %{result: result}, _} -> result
       error -> error


### PR DESCRIPTION
Absinthe 1.4 shipped with the ability to configure the default pipeline
from within the schema module, which allows us to not have to specify a
custom pipeline. Additionally, this helps support test cases where the
absinthe schema is eager loaded, such as for subscriptions.

---

Fixes #8