### PR TITLE
Split tracing and caching middlewares.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ end
 
 ## Usage
 
-### Register the Middleware
+### Register the Middlewares
 
 *ApolloTracing uses the Absinthe's middleware functionality to track field-level resolution times. In order to register our custom middleware, you have a few options:*
 
@@ -33,13 +33,11 @@ def MyApp.Schema do
 end
 ```
 
-**If you have a custom middleware stack, add `ApolloTracing.Middleware` as the first middleware of your middleware stack:**
+**If you have a custom middleware stack, add the apollo tracing middlewares to the beginning of your middleware stack:**
 
 ```elixir
 def middleware(middleware, _field, _object),
-  do: [ApolloTracing.Middleware | ...your other middlewares]
-
-def middleware(middleware, _field, _object), do: middleware
+  do: [ApolloTracing.Middleware.Tracing, ApolloTracing.Middleware.Caching] ++ [...your other middlewares]
 ```
 
 **If you prefer to only add tracing to some fields, you can selectively add tracing information:**

--- a/lib/apollo_tracing.ex
+++ b/lib/apollo_tracing.ex
@@ -7,10 +7,11 @@ defmodule ApolloTracing do
 
   defmacro __using__(_) do
     quote do
-      def middleware(middleware, field, object) do
-        [ApolloTracing.Middleware |
-         Absinthe.Schema.__ensure_middleware__(middleware, field, object)]
-      end
+      def middleware(middleware, _, %{identifier: :subscription}), do: middleware
+      def middleware(middleware, _, %{identifier: :mutation}),
+        do: [ApolloTracing.Middleware.Tracing] ++ middleware
+      def middleware(middleware, _, _),
+        do: [ApolloTracing.Middleware.Tracing, ApolloTracing.Middleware.Caching] ++ middleware
     end
   end
 end

--- a/lib/apollo_tracing/middleware/caching.ex
+++ b/lib/apollo_tracing/middleware/caching.ex
@@ -1,0 +1,31 @@
+defmodule ApolloTracing.Middleware.Caching do
+  @behaviour Absinthe.Middleware
+
+  def call(res, _config) do
+    path =
+      res
+      |> Absinthe.Resolution.path
+      |> Enum.filter(&is_bitstring(&1))
+
+    hint =
+      res.schema
+      |> Absinthe.Schema.lookup_type(res.definition.schema_node.type)
+      |> Absinthe.Type.meta()
+      |> Map.get(:cache, [])
+      |> Enum.into(%{})
+      |> put_in([:path], path)
+
+
+    res.acc
+    |> Map.get(:apollo_caching)
+    |> case do
+      %{hints: hints} ->
+        put_in(res.acc.apollo_caching.hints, [hint | hints])
+      _ ->
+        acc =
+          res.acc
+          |> Map.put(:apollo_caching, %{hints: [hint]})
+        %{res | acc: acc}
+    end
+  end
+end

--- a/lib/apollo_tracing/phase/add_cache_hints.ex
+++ b/lib/apollo_tracing/phase/add_cache_hints.ex
@@ -2,27 +2,26 @@ defmodule ApolloTracer.Phase.AddCacheHints do
   use Absinthe.Phase
 
   def run(bp, _options \\ []) do
-    cache_control_hints = hints(bp.execution.acc.apollo_tracing.execution.resolvers, [])
-    acc = Map.put(bp.execution.acc, :apollo_caching, %{version: 1, hints: cache_control_hints})
-    {:ok, put_in(bp.execution.acc, acc)}
+    case get_in(bp.execution.acc, [:apollo_caching, :hints]) do
+      nil ->
+        {:ok, bp}
+      found ->
+        {:ok, put_in(bp.execution.acc.apollo_caching, %{version: 1, hints: hints(found, [])})}
+    end
   end
 
   defp hints([], result), do: result
-  defp hints([%{meta: meta, path: path} | tail], result) do
-    meta
-    |> Map.get(:cache, [])
-    |> Enum.into(%{})
-    |> hint(path)
+
+  defp hints([%{max_age: max_age, path: path} = head | tail], result) do
+    hint(max_age, Map.get(head, :scope), path)
     |> case do
       nil -> hints(tail, result)
       h -> hints(tail, [h | result])
     end
   end
+  defp hints([_ | tail], result), do: hints(tail, result)
 
-  defp hint(%{max_age: max_age} = hint, path) do
-    scope = if Map.get(hint, :scope) == :private, do: "PRIVATE", else: "PUBLIC"
-    paths = Enum.filter(path, &(is_bitstring(&1)))
-    %{path: paths, maxAge: max_age, scope: scope}
-  end
-  defp hint(_, _), do: nil
+  defp hint(nil, _, _), do: nil
+  defp hint(max_age, :private, path), do: %{path: path, maxAge: max_age, scope: "PRIVATE"}
+  defp hint(max_age, _, path), do: %{path: path, maxAge: max_age, scope: "PUBLIC"}
 end

--- a/lib/apollo_tracing/phase/add_extension.ex
+++ b/lib/apollo_tracing/phase/add_extension.ex
@@ -3,9 +3,21 @@ defmodule ApolloTracer.Phase.AddExtension do
 
   def run(bp, _options \\ []) do
     extensions = Map.get(bp.result, :extensions, %{})
-                 |> Map.put(:tracing, bp.execution.acc.apollo_tracing)
-                 |> Map.put(:cacheControl, bp.execution.acc.apollo_caching)
+
+    extensions = case Map.get(bp.execution.acc, :apollo_tracing) do
+      nil -> extensions
+      tracing ->
+        Map.put(extensions, :tracing, tracing)
+    end
+
+    extensions = case Map.get(bp.execution.acc, :apollo_caching) do
+      nil -> extensions
+      cache ->
+        Map.put(extensions, :cacheControl, cache)
+    end
+
     result = Map.put(bp.result, :extensions, extensions)
+
     {:ok, %{bp | result: result}}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ApolloTracing.Mixfile do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
 
   def project do
     [

--- a/test/apollo_tracing_test.exs
+++ b/test/apollo_tracing_test.exs
@@ -83,15 +83,15 @@ defmodule ApolloTracingTest do
     assert result.extensions.cacheControl.version == 1
     assert result.extensions.cacheControl.hints == [
       %{
+        "path": ["getPerson"],
+        "maxAge": 30,
+        "scope": "PRIVATE",
+      },
+      %{
         "path": ["getPerson", "cars"],
         "maxAge": 600,
         "scope": "PUBLIC",
       },
-      %{
-        "path": ["getPerson"],
-        "maxAge": 30,
-        "scope": "PRIVATE",
-      }
     ]
   end
 end


### PR DESCRIPTION
The entire tracing resolver gets placed into the extension, so we can't
include all of meta in the resolver, because the KeywordList is not
serializable.

I also refactored a few functions to hopefully be a bit more readable.