### PR TITLE
Implementing Jason.Encoder protocol for schema structs

### DIFF
--- a/lib/apollo_tracing/schema.ex
+++ b/lib/apollo_tracing/schema.ex
@@ -2,6 +2,7 @@ defmodule ApolloTracing.Schema do
   @moduledoc """
   Tracing Schema
   """
+  @derive Jason.Encoder
   defstruct [:version,
              :startTime,
              :endTime,
@@ -17,6 +18,7 @@ defmodule ApolloTracing.Schema do
   }
 
   defmodule Execution do
+    @derive Jason.Encoder
     defstruct [:resolvers]
 
     @type t :: %__MODULE__{
@@ -24,6 +26,7 @@ defmodule ApolloTracing.Schema do
     }
 
     defmodule Resolver do
+      @derive Jason.Encoder
       defstruct [:path,
                  :parentType,
                  :fieldName,


### PR DESCRIPTION
This is a small fix that adds implementation of `Jason.Encoder` protocol.
In my app both your run-of-the-mill exceptions and client mistakes in implementing GraphQL schema resulted in errors like:
```elixir
[error] #PID<0.1174.0> running MobileAPI.Endpoint (connection #PID<0.1173.0>, stream id 1) terminated
Server: localhost:4000 (http)
Request: POST /graphql
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for %ApolloTracing.Schema{duration: nil, endTime: nil, execution: %ApolloTracing.Schema.Execution{resolvers: []}, startTime: "2019-08-13T19:24:16.773688Z", version: 1} of type ApolloTracing.Schema (a struct), Jason.Encoder protocol must always be explicitly implemented.
```
that got passed through response to Apollo Proxy which resulted in unhelpful error like:
```json
{
  "errors": [
    {
      "message": "Error decoding JSON response from origin"
    }
  ]
}
```

While I can fix it on my side with:
```elixir
require Protocol
Protocol.derive(Jason.Encoder, ApolloTracing.Schema.Execution.Resolver)
Protocol.derive(Jason.Encoder, ApolloTracing.Schema.Execution)
Protocol.derive(Jason.Encoder, ApolloTracing.Schema)
```
I believe it would be better if it got fixed in lib itself.

---
Erlang/OTP 22
Elixir 1.9.1
absinthe             1.4.16                    
absinthe_phoenix     1.4.4                     
absinthe_plug        1.4.7                        
apollo_tracing       0.4.1  
jason                1.1.2 
phoenix              1.4.9  